### PR TITLE
female^epic

### DIFF
--- a/macros/traits.mac.cfg
+++ b/macros/traits.mac.cfg
@@ -13,7 +13,7 @@
     [trait]
         id=aww_trait_gifted
         male_name="<span color='#ffc950'><i>"+_"epic"+"</i></span>"
-        female_name="<span color='#ffc950'>"+_"female^epic"+"</i></span>"
+        female_name="<span color='#ffc950'><i>"+_"female^epic"+"</i></span>"
         help_text=_"<italic>text='Epic'</italic>, gifted with great potential or trained by the bests, this unit is unrivaled on a battlefield."
 
         ## Displayed effects in trait :


### PR DESCRIPTION
There's a typo where epic info is displayed with an error. Reason: missing <i>
fixed